### PR TITLE
Queries pointing to curated t_short_cpe_exported

### DIFF
--- a/pkg/models/cpe_purl.go
+++ b/pkg/models/cpe_purl.go
@@ -82,12 +82,12 @@ func (m *CpePurlModel) GetCpesByPurlString(purlString string, purlReq string) ([
 	var allCpes []CpePurl
 	zlog.S.Debugf("ctx %v", m.ctx)
 	err := m.conn.SelectContext(m.ctx, &allCpes,
-		"SELECT tcp.cpe, v.version_name, v.semver"+
-			" FROM cpes tcp"+
-			" INNER JOIN short_cpe_purl tscp ON tcp.short_cpe_id = tscp.short_cpe_id"+
-			" INNER JOIN purls tp ON tscp.purl_id = tp.id"+
-			" INNER JOIN versions v ON tcp.version_id = v.id"+
-			" WHERE tp.purl = $1"+
+		"SELECT tcp.cpe, v.version_name, v.semver "+
+			"FROM cpes tcp "+
+			"INNER JOIN t_short_cpe_purl_exported tscp ON tcp.short_cpe_id = tscp.cpe_id  "+
+			"INNER JOIN purls tp ON tscp.purl_id = tp.id "+
+			"INNER JOIN versions v ON tcp.version_id = v.id "+
+			"WHERE tp.purl  = $1"+
 			" ORDER BY v.version_name NULLS LAST;",
 		purlString)
 
@@ -114,10 +114,10 @@ func (m *CpePurlModel) GetCpesByPurlStringVersion(purlString, purlVersion string
 	var cpuPurls []CpePurl
 	err := m.conn.SelectContext(m.ctx, &cpuPurls,
 		"SELECT tc.cpe, v.version_name, v.semver "+
-			" FROM cpes tc"+
-			" INNER JOIN short_cpe_purl scp ON tc.short_cpe_id = scp.short_cpe_id"+
-			" INNER JOIN purls p ON scp.purl_id = p.id"+
-			" INNER JOIN versions v ON tc.version_id = v.id"+
+			"FROM cpes tc "+
+			"INNER JOIN t_short_cpe_purl_exported scp ON tc.short_cpe_id = scp.cpe_id "+
+			"INNER JOIN purls p ON scp.purl_id = p.id "+
+			"INNER JOIN versions v ON tc.version_id = v.id "+
 			" WHERE p.purl = $1 AND v.version_name=$2;",
 		purlString, purlVersion)
 	if err != nil {

--- a/pkg/models/tests/short_cpe_purl.sql
+++ b/pkg/models/tests/short_cpe_purl.sql
@@ -1,59 +1,59 @@
-DROP TABLE IF EXISTS short_cpe_purl;
-CREATE TABLE "short_cpe_purl" (
-                                  "short_cpe_id"	INTEGER NOT NULL,
+DROP TABLE IF EXISTS t_short_cpe_purl_exported;
+CREATE TABLE "t_short_cpe_purl_exported" (
+                                  "cpe_id"	INTEGER NOT NULL,
                                   "purl_id"	INTEGER NOT NULL,
-                                  PRIMARY KEY("short_cpe_id","purl_id")
+                                  PRIMARY KEY("cpe_id","purl_id")
 );
 
 
 
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (4772, 19304);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (4772, 6781);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (40676, 12377);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (6930, 22887);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (6930, 22665);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (6930, 18591);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (6930, 10060);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (6930, 22890);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (54546, 25014);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (9517, 24116);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (40143, 8505);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (40143, 12025);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (40143, 17269);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (31044, 17507);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (50021, 4048);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (50021, 10316);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (24723, 24815);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (32816, 19906);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (32816, 23260);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (32816, 1646);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (32816, 10692);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (32816, 3023);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (32816, 5153);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (32816, 9550);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (44876, 11524);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (8270, 25794);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (8270, 1176);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (23153, 22770);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (17559, 24096);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (17559, 2429);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (36858, 15022);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (36858, 6062);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (54486, 11962);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (54486, 18047);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (20819, 24539);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (20819, 2595);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (48168, 14558);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (48168, 23242);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (4970, 22410);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (4970, 10569);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (4970, 7072);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (4970, 17949);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (4970, 11242);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (48783, 26613);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (11798, 20614);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (6591, 9741);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (8296, 6121);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (8296, 1739);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (8296, 17342);
-INSERT INTO short_cpe_purl ("short_cpe_id", "purl_id") VALUES (8296, 14642);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (4772, 19304);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (4772, 6781);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (40676, 12377);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (6930, 22887);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (6930, 22665);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (6930, 18591);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (6930, 10060);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (6930, 22890);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (54546, 25014);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (9517, 24116);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (40143, 8505);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (40143, 12025);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (40143, 17269);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (31044, 17507);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (50021, 4048);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (50021, 10316);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (24723, 24815);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (32816, 19906);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (32816, 23260);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (32816, 1646);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (32816, 10692);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (32816, 3023);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (32816, 5153);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (32816, 9550);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (44876, 11524);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (8270, 25794);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (8270, 1176);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (23153, 22770);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (17559, 24096);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (17559, 2429);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (36858, 15022);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (36858, 6062);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (54486, 11962);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (54486, 18047);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (20819, 24539);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (20819, 2595);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (48168, 14558);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (48168, 23242);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (4970, 22410);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (4970, 10569);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (4970, 7072);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (4970, 17949);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (4970, 11242);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (48783, 26613);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (11798, 20614);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (6591, 9741);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (8296, 6121);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (8296, 1739);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (8296, 17342);
+INSERT INTO t_short_cpe_purl_exported ("cpe_id", "purl_id") VALUES (8296, 14642);

--- a/pkg/models/vulns_purl.go
+++ b/pkg/models/vulns_purl.go
@@ -88,13 +88,12 @@ func (m *VulnsForPurlModel) GetVulnsByPurlName(purlName string) ([]VulnsForPurl,
 	var vulns []VulnsForPurl
 	purlName = strings.TrimSpace(purlName)
 	err := m.conn.SelectContext(m.ctx, &vulns,
-		" select distinct cves.cve, cves.severity, cves.published, cves.modified, cves.summary "+
-			"from purls p "+
-			"inner join short_cpe_purl tscp on p.id = tscp.purl_id "+
-			"inner join cpes tc on tscp.short_cpe_id = tc.short_cpe_id "+
+		"select distinct cves.cve, cves.severity, cves.published, cves.modified, cves.summary from purls p "+
+			"inner join t_short_cpe_purl_exported tscp on p.id = tscp.purl_id "+
+			"inner join cpes tc on tscp.cpe_id   = tc.id  "+
 			"inner join cpe_cve tcc on tc.id = tcc.cpe_id "+
 			"inner join cves on cves.id = tcc.cve_id "+
-			"where p.purl = $1;", purlName)
+			"where p.purl= $1;", purlName)
 
 	if err != nil {
 		zlog.S.Errorf("Failed to query short_cpe for %s: %v", purlName, err)
@@ -116,8 +115,8 @@ func (m *VulnsForPurlModel) GetVulnsByPurlVersion(purlName string, purlVersion s
 	err := m.conn.SelectContext(m.ctx, &vulns,
 		"select cves.cve, cves.severity, cves.published, cves.modified, cves.summary "+
 			"from purls p "+
-			"inner join short_cpe_purl tscp on p.id = tscp.purl_id "+
-			"inner join cpes tc on tscp.short_cpe_id = tc.short_cpe_id "+
+			"inner join t_short_cpe_purl_exported tscpe  on p.id = tscpe.purl_id "+
+			"inner join cpes tc on tscpe.cpe_id = tc.short_cpe_id "+
 			"inner join cpe_cve tcc on tc.id = tcc.cpe_id "+
 			"inner join cves on cves.id = tcc.cve_id "+
 			"inner join versions v on tc.version_id = v.id "+


### PR DESCRIPTION
Queries containing old short_cpe_purl table where modified to query from t_short:_cpe_purl_exported that is the one that contains curated entries.