### PR TITLE
chore:SP-3129 Removes 'api' prefix from REST endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [0.6.0] - 2025/08/29
+### Changed
+- Replaced REST endpoint GET `/api/v2/vulnerabilities/cpes/component` by `/v2/vulnerabilities/cpes/component`
+- Replaced REST endpoint POST `/api/v2/vulnerabilities/cpes/components` by `/v2/vulnerabilities/cpes/components`
+- Replaced REST endpoint GET `/api/v2/vulnerabilities/component` by `/v2/vulnerabilities/component`
+- Replaced REST endpoint POST `/api/v2/vulnerabilities/components` by `/v2/vulnerabilities/components`
+- Replaced REST endpoint POST `/api/v2/vulnerabilities/echo` by `/v2/vulnerabilities/echo`
+- Updated `github.com/scanoss/papi` to v0.17.0
+
 ## [0.5.0] - 2025/08/28
 ### Added
 - Added new vulnerability PAPI definitions
@@ -54,3 +63,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.3.0]: https://github.com/scanoss/vulnerabilities/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/scanoss/vulnerabilities/compare/v0.3.0...v0.4.0
 [0.5.0]: https://github.com/scanoss/vulnerabilities/compare/v0.4.0...v0.5.0
+[0.6.0]: https://github.com/scanoss/vulnerabilities/compare/v0.5.0...v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pandatix/go-cvss v0.6.2
 	github.com/scanoss/go-grpc-helper v0.9.0
 	github.com/scanoss/go-models v0.2.0
-	github.com/scanoss/papi v0.15.0
+	github.com/scanoss/papi v0.17.0
 	github.com/scanoss/zap-logging-helper v0.4.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.75.0

--- a/go.sum
+++ b/go.sum
@@ -659,8 +659,8 @@ github.com/scanoss/go-purl-helper v0.2.1 h1:jp960a585ycyJSlqZky1NatMJBIQi/JGITDf
 github.com/scanoss/go-purl-helper v0.2.1/go.mod h1:v20/bKD8G+vGrILdiq6r0hyRD2bO8frCJlu9drEcQ38=
 github.com/scanoss/ipfilter/v2 v2.0.2 h1:GaB9i8kVJg9JQZm5XGStYkEpiaCVdsrj7ezI2wV/oh8=
 github.com/scanoss/ipfilter/v2 v2.0.2/go.mod h1:AwrpX4XGbZ7EKISMi1d6E5csBk1nWB8+ugpvXHFcTpA=
-github.com/scanoss/papi v0.15.0 h1:dOoXpjzp/mIeIlb/sHVTKWDKwA2hIvcp1R7nHjfh+H4=
-github.com/scanoss/papi v0.15.0/go.mod h1:Z4E/4IpwYdzHHRJXTgBCGG1GjksgrFjNW5cvhbKUfeU=
+github.com/scanoss/papi v0.17.0 h1:YKS6hN1hXbE0yV9LwAridOreNLTPfrwFozUfbrAYv+Y=
+github.com/scanoss/papi v0.17.0/go.mod h1:Z4E/4IpwYdzHHRJXTgBCGG1GjksgrFjNW5cvhbKUfeU=
 github.com/scanoss/zap-logging-helper v0.4.0 h1:2qTYoaFa9+MlD2/1wmPtiDHfh+42NIEwgKVU3rPpl0Y=
 github.com/scanoss/zap-logging-helper v0.4.0/go.mod h1:9QuEZcq73g/0Izv1tWeOWukoIK0oTBzM4jSNQ5kRR1w=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
## WHAT

### Changed
- Replaced REST endpoint GET `/api/v2/vulnerabilities/cpes/component` by `/v2/vulnerabilities/cpes/component`
- Replaced REST endpoint POST `/api/v2/vulnerabilities/cpes/components` by `/v2/vulnerabilities/cpes/components`
- Replaced REST endpoint GET `/api/v2/vulnerabilities/component` by `/v2/vulnerabilities/component`
- Replaced REST endpoint POST `/api/v2/vulnerabilities/components` by `/v2/vulnerabilities/components`
- Replaced REST endpoint POST `/api/v2/vulnerabilities/echo` by `/v2/vulnerabilities/echo`
- Updated `github.com/scanoss/papi` to v0.17.0