### PR TITLE
chore:SP-3356 Updates default gRPC, REST and logging ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [0.6.1] - 2025/09/29
+### Changed
+- Updated default ports: REST `40052`, gRPC `50052`, and logging `66052`
+
 ## [0.6.0] - 2025/08/29
 ### Changed
 - Replaced REST endpoint GET `/api/v2/vulnerabilities/cpes/component` by `/v2/vulnerabilities/cpes/component`
@@ -64,3 +68,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.4.0]: https://github.com/scanoss/vulnerabilities/compare/v0.3.0...v0.4.0
 [0.5.0]: https://github.com/scanoss/vulnerabilities/compare/v0.4.0...v0.5.0
 [0.6.0]: https://github.com/scanoss/vulnerabilities/compare/v0.5.0...v0.6.0
+[0.6.1]: https://github.com/scanoss/vulnerabilities/compare/v0.6.0...v0.6.1

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,12 @@ build_arm: version  ## Build an ARM 64 binary
 	go generate ./pkg/cmd/server.go
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-w -s" -o ./target/scanoss-vulnerabilities-api-linux-arm64 ./cmd/server
 
+build_arm: version  ## Build an ARM 64 binary
+	@echo "Building ARM binary $(VERSION)..."
+	go generate ./pkg/cmd/server.go
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-w -s" -o ./target/scanoss-vulnerabilities-api-darwin-arm64 ./cmd/server
+
+
 package: package_amd  ## Build & Package an AMD 64 binary
 
 package_amd: version  ## Build & Package an AMD 64 binary

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	defaultGrpcPort = "50051"
-	defaultRestPort = "40051"
+	defaultGrpcPort = "50052"
+	defaultRestPort = "40052"
 )
 
 // ServerConfig is configuration for Server.
@@ -114,7 +114,7 @@ func setServerConfigDefaults(cfg *ServerConfig) {
 	cfg.Database.SslMode = "disable"
 	cfg.Database.Trace = false
 	cfg.Logging.DynamicLogging = true
-	cfg.Logging.DynamicPort = "localhost:60054"
+	cfg.Logging.DynamicPort = "localhost:60052"
 	cfg.Telemetry.Enabled = false
 	cfg.Telemetry.OltpExporter = "0.0.0.0:4317" // Default OTEL OLTP gRPC Exporter endpoint
 	cfg.Components.CommitMissing = false


### PR DESCRIPTION
## What's Changed

### Changed
- Updated default ports: REST `40052`, gRPC `50052`, and logging `66052`