### PR TITLE
feat(rest): register /health liveness endpoint via go-grpc-helper v0.16.0 (SP-4474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Upcoming changes...
 
+## [0.13.0] - 2026-06-22
+### Added
+- `/health` liveness endpoint (GET) on the REST gateway
+### Changed
+- Upgraded `scanoss/go-grpc-helper` to `v0.16.0`
+
 ## [0.12.0] - 2026/04/17
 ### Changed
 - Updated dependencies to the latest versions
@@ -135,3 +141,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.10.0]: https://github.com/scanoss/vulnerabilities/compare/v0.9.0...v0.10.0
 [0.11.0]: https://github.com/scanoss/vulnerabilities/compare/v0.10.0...v0.11.0
 [0.12.0]: https://github.com/scanoss/vulnerabilities/compare/v0.11.0...v0.12.0
+[0.13.0]: https://github.com/scanoss/vulnerabilities/compare/v0.12.0...v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/package-url/packageurl-go v0.1.5
 	github.com/pandatix/go-cvss v0.6.2
 	github.com/scanoss/go-component-helper v0.6.0
-	github.com/scanoss/go-grpc-helper v0.15.1
+	github.com/scanoss/go-grpc-helper v0.16.0
 	github.com/scanoss/go-purl-helper v0.3.0
 	github.com/scanoss/papi v0.40.0
 	github.com/scanoss/zap-logging-helper v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/scanoss/go-component-helper v0.6.0 h1:tizjG6Fue2mWZLFtnHP8I6OaPze03Im5AfqBcNfW4bo=
 github.com/scanoss/go-component-helper v0.6.0/go.mod h1:UwsyuM5uvCrGeBIkvewgMAKV92Sjjvo7zelq4c2m91Y=
-github.com/scanoss/go-grpc-helper v0.15.1 h1:tiI7JXVj2LYpktkYVqCcUd6XyMi6aVcAKRecNR5QGCA=
-github.com/scanoss/go-grpc-helper v0.15.1/go.mod h1:UjrF9hewgZxstUC3+F0PJnuOXH0bChmsbcJp7e7OsH4=
+github.com/scanoss/go-grpc-helper v0.16.0 h1:RwFY2iZQ9JQWR0kewBviF1MevfpCBdkijoh+KaYRuEI=
+github.com/scanoss/go-grpc-helper v0.16.0/go.mod h1:UjrF9hewgZxstUC3+F0PJnuOXH0bChmsbcJp7e7OsH4=
 github.com/scanoss/go-models v0.8.0 h1:ANprMXby+J9vxj205EfH7roVzAsUJdcTenytPea4N/k=
 github.com/scanoss/go-models v0.8.0/go.mod h1:gkXP2/3ZUn8IyH/z/528aTcWZ2mzlzsXiY4bzBbrM+o=
 github.com/scanoss/go-purl-helper v0.3.0 h1:zH5rcYbmYTvKms2oWrYV+8rWZ2ElLgDIOy2jZ9XhAg0=

--- a/pkg/protocol/rest/server.go
+++ b/pkg/protocol/rest/server.go
@@ -38,6 +38,10 @@ func RunServer(config *myconfig.ServerConfig, ctx context.Context, grpcPort, htt
 	if err != nil {
 		return nil, err
 	}
+	// register the liveness /health endpoint on the gateway mux
+	if err = gw.RegisterHealthEndpoint(mux); err != nil {
+		return nil, err
+	}
 	// Open TCP port (in the background) and listen for requests
 	go func() {
 		ctx2, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
Adds a real GET `/health` liveness endpoint on the REST gateway by adopting go-grpc-helper v0.16.0 (`gw.RegisterHealthEndpoint`).

- Bumps `scanoss/go-grpc-helper` to `v0.16.0`
- Registers GET `/health` on the gateway mux

SP-4474 (parent SP-4472).